### PR TITLE
[dactylo] Improve contrast on light theme.

### DIFF
--- a/css/demo.css
+++ b/css/demo.css
@@ -66,8 +66,8 @@ dialog::backdrop {
   text-wrap: break;
 }
 
-.keyboard #lesson { color: #444; }
-.keyboard .done   { color: gray; }
+.keyboard #lesson { color: #333; }
+.keyboard .done   { color: #999; }
 .keyboard .error  { color: red; }
 .keyboard .space  { display: inline-block; }
 .keyboard .space::before { content: "·"; }


### PR DESCRIPTION
This should hopefully resolve #60. Sadly we can’t use green (as suggested) since that color is used by the upcoming PR #61 when we fix a typo. I used slightly different shades of gray, which I think is enough but I’m not quite sure. Here’s a before and after comparison :

Before :
![image](https://github.com/Nuclear-Squid/ergol/assets/70967142/9792d45e-c3d1-44f2-b877-85b4778b0378)

After :
![Screenshot 2024-02-15 at 17-03-41 Ergo‑L](https://github.com/Nuclear-Squid/ergol/assets/70967142/2b6ff145-b0e8-4f0a-91db-c0ea0a71d52b)