### PR TITLE
Add a table of contents in the Lafayette* page.

### DIFF
--- a/www/content/lafayette.md
+++ b/www/content/lafayette.md
@@ -10,6 +10,14 @@ jsScripts = ["/js/keebs.js"]
 Une série de disposition de clavier été adaptées au français et/ou aux claviers
 ergonomiques via une touche « Typo ».
 
+:::{.highlight}
+- [QWERTY-Lafayette]
+  <br/>Là où tout a commencé.
+- [Colemak French Touch]
+  <br/>Colemak avec l’accent français.
+- [Bépolar]
+  <br/>Bépo en 1DFH.
+:::
 
 QWERTY-Lafayette
 --------------------------------------------------------------------------------

--- a/www/content/lafayette.md
+++ b/www/content/lafayette.md
@@ -72,7 +72,7 @@ préserver le raccourci [Ctrl]{.kbd}‑[V]{.kbd}. Il s’agit donc d’une varia
 « HUY ».
 
 Au final, on obtient une distribution avec d’excellentes statistiques, parfaite
-pour les personnes qui tapent actuellement en Colemak mais qui on un besoin
+pour les personnes qui tapent actuellement en Colemak mais qui ont un besoin
 régulier d’écrire en français. Comme toutes les autres dispositions de la
 famille, on conserve également la couche facultative [AltGr]{.kbd}, parfait pour
 la programmation.
@@ -88,7 +88,7 @@ Dérivé de Bépo, Bépolar s’adapte aux claviers compacts. C’est une dispos
 s’appuyant sur des mécanismes modernes (1DFH, touche typographique) afin
 d’améliorer le confort de frappe.
 
-La disposition est _plus confortable_ que Bépo en Français, et _meilleure_ que
+La disposition est _plus confortable_ que Bépo en français, et _meilleure_ que
 Bépo pour l’anglais et la programmation avec sa couche [AltGr]{.kbd} commune à
 Ergo-L.
 


### PR DESCRIPTION
This PR proposes the following two changes:
- Add a table of contents in the “Lafayette*” page (their description can be edited as you see fit);
- Fix a couple of typos in the aforementioned page.