### PR TITLE
css: Fix anchors styling

### DIFF
--- a/www/assets/css/theme.css
+++ b/www/assets/css/theme.css
@@ -141,12 +141,12 @@ ul {
   padding-left: 1.5em;
 }
 
-a {
+a[href] {
   color: var(--fg-accent);
   text-decoration: none;
 }
 
-a:hover {
+a[href]:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
`<a>` tags may also be used as anchors, so target only tags with `href` attributes to style links.