### PR TITLE
[keebs] layer/geometry selectors should be either on each side of the keyboard or stacked in the center

### DIFF
--- a/www/assets/css/keebs.css
+++ b/www/assets/css/keebs.css
@@ -96,7 +96,7 @@
   text-align: center;
 }
 
-@media only screen and (min-width: 600px) {
+@media only screen and (min-width: 768px) {
   .keyboard form { justify-content: space-between; }
 }
 

--- a/www/assets/css/keebs.css
+++ b/www/assets/css/keebs.css
@@ -108,7 +108,6 @@
 **/
 
 .keyboard nav {
-  display: none;
   text-align: center;
   text-wrap: balance;
   margin: 1em auto;
@@ -116,7 +115,7 @@
 
 .keyboard nav a,
 .keyboard nav button {
-  display: none;
+  display: inline;
   box-sizing: border-box;
   margin: 2px 1px;
   padding: 0 6px;
@@ -125,6 +124,7 @@
 }
 
 .keyboard nav button {
+  display: none;
   font-weight: bold;
   cursor: pointer;
   color: var(--fg-main);
@@ -133,11 +133,6 @@
 .keyboard [disabled] {
   pointer-events: none;
   opacity: 0.3;
-}
-
-@media only screen and (min-width: 480px) {
-  .keyboard nav   { display: block;  }
-  .keyboard nav a { display: inline; }
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
This solves the presentation glitch I mentioned in #137 by hiding the layer selector when the device is smaller than 480px. I think such width makes it too small to see the key details anyway, but switching to landscape mode brings the selector back as the keymap becomes more readable.

@wismill, wdyt ? I’ve also modified the media query a bit to keep the same breakpoints (480px / 768px). Should we have global variables for this ?