### PR TITLE
Convention typographique pour les couches et touches associées

### DIFF
--- a/www/content/alternatives/index.md
+++ b/www/content/alternatives/index.md
@@ -202,7 +202,7 @@ elle est *utilisable*, mais pas *optimisée* pour ça.
 [bépolar]:    /lafayette/#bepolar
 [azerty]:     /stats/#/azerty//en+fr
 
-[1DFH]:                   /#dfh-1u-distance-from-home
-[touche morte]:           /#caractères-accentués
-[couche altgr optimisée]: /#couche-symboles
+[1DFH]:                   /presentation#dfh-1u-distance-from-home
+[touche morte]:           /presentation#caractères-accentués
+[couche altgr optimisée]: /presentation#couche-symboles
 [défauts d’ergonomie]:    /bepo/#ergonomie

--- a/www/content/alternatives/index.md
+++ b/www/content/alternatives/index.md
@@ -108,17 +108,17 @@ avoir les chiffres en direct. Néanmoins, il restera le problème des touches
 excentrées sous l’auriculaire droit, qui causent des déviations ulnaires.
 
 **De notre point de vue,** [Lafayette][] peut apporter une solution ergonomique
-intéressante ([1DFH][], [couche AltGr optimisée][]) moyennant un temps
-d’apprentissage minime.
+intéressante ([1DFH][], [couche _Symboles_ optimisée][symboles]) moyennant un
+temps d’apprentissage minime.
 
 
 ### Les « Ergonautes »
 
 [Ergo‑L][], [Erglace][], [Colemak FT][], [Bépolar][], [Lafayette][], toutes ces
-dispositions partagent une même approche ergonomique : [1DFH][] et [couche AltGr
-optimisée][], garantissant ainsi l’absence d’extensions de doigts (donc de
-déviations ulnaires) et une compatibilité exemplaire avec tous les claviers,
-ergonomiques ou non, de 33 à 105 touches.
+dispositions partagent une même approche ergonomique : [1DFH][] et [couche
+_Symboles_ optimisée][symboles], garantissant ainsi l’absence d’extensions de
+doigts (donc de déviations ulnaires) et une compatibilité exemplaire avec tous
+les claviers, ergonomiques ou non, de 33 à 105 touches.
 
 - Ergo‑L est le projet le plus abouti, destiné au plus grand nombre, bien plus
   optimisé que Bépo en français et que Dvorak en anglais, tout en gardant un
@@ -202,7 +202,7 @@ elle est *utilisable*, mais pas *optimisée* pour ça.
 [bépolar]:    /lafayette/#bepolar
 [azerty]:     /stats/#/azerty//en+fr
 
-[1DFH]:                   /presentation#dfh-1u-distance-from-home
-[touche morte]:           /presentation#caractères-accentués
-[couche altgr optimisée]: /presentation#couche-symboles
-[défauts d’ergonomie]:    /bepo/#ergonomie
+[1DFH]:                /presentation#dfh-1u-distance-from-home
+[touche morte]:        /presentation#caractères-accentués
+[symboles]:            /presentation#couche-symboles
+[défauts d’ergonomie]: /bepo/#ergonomie

--- a/www/content/bepo/index.md
+++ b/www/content/bepo/index.md
@@ -289,8 +289,8 @@ touches répétées sous les auriculaires.
 ![La couche Symboles d’Ergo‑L.](/img/ergol_altgr.svg)
 
 La touche [AltGr]{.kbd} reste facultative, les symboles étant également
-disponibles [aux emplacements du QWERTY ANSI](/#héritage-qwerty-us), une
-disposition de clavier perçue comme efficace pour cet usage.
+disponibles [aux emplacements du QWERTY ANSI](/presentation#héritage-qwerty-us),
+une disposition de clavier perçue comme efficace pour cet usage.
 
 
 Variantes de Bépo
@@ -336,8 +336,8 @@ beaucoup trop élevé à notre avis — à comparer aux 6.9 % pour Ergo‑L. *
   personnes qui ont des difficultés avec Bépo.
 
 
-[1DFH]: /#dfh-1u-distance-from-home.
-[ergonomique avant tout]: /#ergonomique-avant-tout)
+[1DFH]: /presentation#dfh-1u-distance-from-home.
+[ergonomique avant tout]: /presentation#ergonomique-avant-tout)
 
 [bépo]:      https://bepo.fr
 [dvorak]:    https://fr.wikipedia.org/wiki/Disposition_Dvorak

--- a/www/content/bepo/index.md
+++ b/www/content/bepo/index.md
@@ -238,8 +238,8 @@ Typographie
   enchaînements : `ù`, `œ`, `æ`, points de suspension…
 
 De plus, Bépo propose beaucoup de caractères spéciaux (i.e. non liés à la langue
-français ou au code informatique) via la couche AltGr ou des touches mortes, au
-prix d’une certaine complexité des pilotes de clavier :
+français ou au code informatique) via la couche _AltGr_ ou des touches mortes,
+au prix d’une certaine complexité des pilotes de clavier :
 
 - les pilotes Windows existent en deux versions, l’une « tronquée » et stable,
   l’autre « complète » mais dont le comportement est présenté comme moins
@@ -270,7 +270,7 @@ mais pour les autres caractères spéciaux Ergo‑L se contente des touches mort
 standard définies dans XKB afin de proposer des pilotes plus robustes.
 Les autres caractères spéciaux sont laissés à la touche Compose.
 
-![La couche Typo d’Ergo‑L.](/img/ergol_1dk.svg)
+![La couche _Typo_ d’Ergo‑L.](/img/ergol_1dk.svg)
 
 **De notre point de vue** : la saisie de la plupart des caractères accentués
 est plus intuitive avec Bépo. L’approche d’Ergo‑L permet d’éviter les extensions

--- a/www/content/lafayette.md
+++ b/www/content/lafayette.md
@@ -101,9 +101,9 @@ C’est un bon moyen, pour un bépoète, de tester l’approche 1DFH avec un tem
 d’apprentissage record.
 
 
-[1]: /#dfh-1u-distance-from-home
-[2]: /#impeccable-en-français
-[3]: /#couche-symboles
+[1]: /presentation#dfh-1u-distance-from-home
+[2]: /presentation#impeccable-en-français
+[3]: /presentation#couche-symboles
 
 [kalamine]:   https://github.com/OneDeadKey/kalamine
 [x‑keyboard]: https://github.com/OneDeadKey/x-keyboard

--- a/www/content/presentation/index.md
+++ b/www/content/presentation/index.md
@@ -165,7 +165,7 @@ nous semble négligeable comparé au gain de confort obtenu.
   (`â`, `ê`, `î`, `ô`, `û`)
 - … et d’autres altérations : `æ`, `µ`, `ß`, `ñ`…
 
-La touche Typo donne parfois accès à une autre touche morte :
+La touche [★]{.odk} donne parfois accès à une autre touche morte :
 
 - [★]{.odk} [★]{.odk} = tréma mort (`ä`, `ë`, `ï`, `ö`, `ü`, `ÿ`…)
 - [★]{.odk} [G]{.kbd} = touche morte grecque (`α`, `β`, `γ`…)
@@ -225,7 +225,7 @@ Efficace en anglais
 Ergo‑L porte la même attention au confort de la saisie de texte en anglais qu’en
 français, et doit donc faire quelques compromis pour faire cohabiter les deux
 langues. Certaines lettres sont beaucoup plus fréquentes dans une langue que
-l’autre, (comme le [U]{.kbd} et la touche typo en français et le [H]{.kbd} en
+l’autre, (comme le [U]{.kbd} et la touche [★]{.odk} en français et le [H]{.kbd} en
 anglais) et les enchaînements courants peuvent être très différents.
 
 Ergo‑L optimise le plus possible la saisie de texte anglais et français sans
@@ -251,7 +251,7 @@ optimisée pour le français **et** l’anglais*.
 Ergo‑L est capable de saisir du texte dans presque toutes le langues
 européennes, mais ne cherche pas à optimiser la saisie de texte dans d’autres
 langues que le français et l’anglais. Certains caractères sont disponibles en
-touche typo, comme `ß` ou `ñ`, et il existe de nombreuses touches mortes en
+touche [★]{.odk}, comme `ß` ou `ñ`, et il existe de nombreuses touches mortes en
 [Shift]{.kbd}‑[AltGr]{.kbd} : par exemple, `^` étant en [AltGr]{.kbd}‑[J]{.kbd},
 [Shift]{.kbd}‑[AltGr]{.kbd}‑[J]{.kbd} produit un accent circonflexe mort.
 
@@ -271,7 +271,7 @@ de clavier cherchant à couvrir toutes les langues !
 ![Un exemple d’adaptation d’Ergo‑L pour l’allemand.](ergol_1dk_de.svg)
 
 Si vous voulez adapter Ergo‑L à une langue étrangère, nous vous recommandons de
-concevoir la couche typo uniquement pour cette langue et d’installer votre
+concevoir la couche _Typo_ uniquement pour cette langue et d’installer votre
 adaptation en même temps qu’Ergo‑L en lui donnant un autre nom (comme
 « ergol-de » pour l’allemand, par exemple). Tous les bureaux modernes proposent
 un raccourci clavier pour basculer d’une langue à l’autre, et vous pourrez ainsi
@@ -303,12 +303,12 @@ une meilleure alternative.
 
 ### Couche symboles
 
-Ergo‑L propose une couche [AltGr]{.kbd} optionelle optimisée pour le placement
-et les enchaînements de symboles de programmation.
+Ergo‑L propose une couche _Symboles_ optionelle accessible par [AltGr]{.kbd} et
+optimisée pour le placement et les enchaînements de symboles de programmation.
 
-![La couche AltGr d’Ergo‑L.](ergol_altgr.svg)
+![La couche _Symboles_ d’Ergo‑L.](ergol_altgr.svg)
 
-Cette couche [AltGr]{.kbd} est plutôt simple à mémoriser, car les symboles sont
+Cette couche _Symboles_ est plutôt simple à mémoriser, car les symboles sont
 regroupés par « blocs ». On y retrouve :
 
 - les délimiteurs `()` `{}` `[]` `<>`
@@ -326,7 +326,7 @@ grande majorité des enchaînements de symboles de prog se fait soit avec une
 alternance de main (`~/`, `);`, `</>`, `+=`, `['']`, …) soit avec un roulement
 (`>=`, `/*`, `";`, `()`, `\"`, …).
 
-Comme pour la saisie de texte en français ou anglais, la couche [AltGr]{.kbd}
+Comme pour la saisie de texte en français ou anglais, la couche _Symboles_
 d’Ergo‑L ne contient pratiquement aucun enchaînement inconfortable.
 
 
@@ -334,7 +334,7 @@ d’Ergo‑L ne contient pratiquement aucun enchaînement inconfortable.
 
 Pour une utilisation technique, Vim apporte une ergonomie reconnue et de
 nombreux éditeurs de code implémentent un mode de navigation Vim. La couche
-[AltGr]{.kbd} d’Ergo‑L lui permet de conserver les principales commandes de
+_Symboles_ d’Ergo‑L lui permet de conserver les principales commandes de
 déplacement :
 
 - [AltGr]{.kbd}‑[R]{.kbd}/[T]{.kbd} (les touches correspondant à
@@ -342,7 +342,7 @@ déplacement :
   de `j`/`k` ;
 - les sauts verticaux `{}`, `()` et `[]` sont en [AltGr]{.kbd} + main gauche.
 
-Cette couche AltGr a été éprouvée dans des contextes techniques variés sans
+Cette couche _Symboles_ a été éprouvée dans des contextes techniques variés sans
 qu’on relève de problème particulier. Elle a été reprise dans d’autres projets,
 notamment [Lafayette] et [Arsenik].
 
@@ -359,7 +359,7 @@ mieux réputées, mais on en a choisi une dont on comprend tous les mots.
  !   │               Balises pour les liens :                │
  !   ╰───────────────────────────────────────────────────────╯
 -->
-[1DFH]:      /#dfh-1u-distance-from-home
+[1DFH]:      /presentation#dfh-1u-distance-from-home
 [WTFPL]:     http://wtfpl.net
 [dvorak]:    https://fr.wikipedia.org/wiki/Disposition_Dvorak
 [bépo]:      https://bepo.fr


### PR DESCRIPTION
Il semble y avoir plusieurs conventions utilisées pour se référer aux couches et aux touches associées. Ce serait bien d’avoir une convention de nommage et typographique pour plus de clarité.

Cette PR vise à démarrer la discussion. Lorsque les conventions seront établies, il faudra ensuite s’assurer de les appliquer sur tout le site.