### PR TITLE
[bugfix] /stats: re-enable layout emulation

### DIFF
--- a/www/content/stats.html
+++ b/www/content/stats.html
@@ -10,7 +10,7 @@ footer = "quantifié par [x-keyboard](https://onedeadkey.github.io/x-keyboard)"
 +++
 
 <div class="keyboard">
-  <input spellcheck="false" />
+  <input spellcheck="false" placeholder="" />
   <x-keyboard></x-keyboard>
 </div>
 


### PR DESCRIPTION
I had to specify `input[placeholder]` in a previous PR so that `querySelector` doesn’t target the radio buttons that we now use to pick a geometry in other pages. And forgot this could break the /stats page because I’m an idiot and we have no unit tests.