### PR TITLE
Suppression de Ergo-L(dev) dans la page Analyseur

### DIFF
--- a/www/layouts/shortcodes/layout-list.html
+++ b/www/layouts/shortcodes/layout-list.html
@@ -15,7 +15,6 @@
     "azerty"      "Azerty"
     "lafayette"   "Lafayette"
     "ergol"       "Ergo‑L"
-    "ergol-dev"   "Ergo‑L (dev)"
     "erglace"     "Erglace"
     "colemak-french-touch" "Colemak French Touch"
     "bepolar"     "Bépolar"


### PR DESCRIPTION
J’ai supprimé la version dev étant donné qu’elle a été remplacée par la v1 ;)