### PR TITLE
fix quote layout

### DIFF
--- a/www/content/alternatives/_index.md
+++ b/www/content/alternatives/_index.md
@@ -180,10 +180,12 @@ inconfortables pour une utilisation régulière (`th`, `yo`, `ay`, `by`, `ok`,
 `ak`, `ki`/`ik`/`ike`). Elle est *utilisable*, mais pas *optimisée* pour ça. Et
 d’ailleurs, son auteur reconnait que l’anglais n’est qu’un objectif secondaire :
 
-> Je peux modifier légèrement Optimot pour optimiser un peu plus pour l’anglais
-> (mais au détriment du français). Mais ce n’est pas mon choix parce que nous
-> sommes en France et que je m’adresse à des personnes qui écrivent d’abord en
-> français.
+<blockquote>
+  Je peux modifier légèrement Optimot pour optimiser un peu plus pour l’anglais
+  (mais au détriment du français). Mais ce n’est pas mon choix parce que nous
+  sommes en France et que je m’adresse à des personnes qui écrivent d’abord en
+  français.
+</blockquote>
 
 <!--
 - 2024-01-27


### PR DESCRIPTION
Pour aligner la présentation sur celle des témoignages de la page d’accueil – si on utilise du MD (`>`) et non du HTML dans le MD (`blockquote`), un saut de ligne est inséré car un `p` est créé.