### PR TITLE
fix: doc: fix '^' rendering as key pressed

### DIFF
--- a/www/content/ressources/glossaire.md
+++ b/www/content/ressources/glossaire.md
@@ -171,7 +171,7 @@ relâchée, mais modifie le comportement de la prochaine touche qui sera enfonc�
 Une touche morte est généralement utilisée pour produire des lettres accentuées
 ou autres [diacritiques].
 
-    Exemple : la touche [^]{.kbd} sur le clavier Azerty puis [E]{.kbd} donne la
+    Exemple : la touche [\^]{.kbd} sur le clavier Azerty puis [E]{.kbd} donne la
     lettre `ê`.
 
 [Diacritique]{#diacritique-def}


### PR DESCRIPTION
The `^` key is not displayed properly on https://ergol.org/ressources/glossaire/ because it's a special character so it must be escaped.

![Screenshot 2025-01-03 at 13-50-10 Glossaire Ergo‑L](https://github.com/user-attachments/assets/31ba7bd3-d931-41f2-b2af-6d8e3fc96717)
