### PR TITLE
add missing characters to ergol.svg

### DIFF
--- a/www/static/img/ergol.svg
+++ b/www/static/img/ergol.svg
@@ -645,6 +645,7 @@
           <text x="38.0" y="20.6" class="level4">≠</text>
           <text x="38.0" y="43.4" class="level5"> </text>
         </g>
+        <text x="38.0" y="43.4" class="level5">ñ</text>
       </g>
     </g>
     <g class="right">
@@ -759,6 +760,7 @@
             <text x="38.0" y="20.6" class="dk_mark">◌</text>
             <text x="38.0" y="20.6" class="dk_char">,</text>
           </g>
+          <text x="38.0" y="43.4" class="level5">ß</text>
         </g>
       </g>
       <g id="KeyC" class="letterKey" transform="translate(255)">


### PR DESCRIPTION
'ß' and 'ñ' are added.

I didn't add the different versions of '-' but I can add them if you want.

I wonder if [ergo_full.svg](https://raw.githubusercontent.com/Nuclear-Squid/ergol/refs/heads/main/www/static/img/ergol_full.svg) should be removed or not. It's not used in the website and the picture is less 'full' than [ergo.svg](https://raw.githubusercontent.com/Nuclear-Squid/ergol/refs/heads/main/www/static/img/ergol.svg).