### PR TITLE
Mise à jour du lien du site Ergopti

### DIFF
--- a/www/content/articles/analyse_et_optimisation/index.md
+++ b/www/content/articles/analyse_et_optimisation/index.md
@@ -905,7 +905,7 @@ Ergonautes est fantastique. 🚀
 [Nuclear Squid]:           https://github.com/Nuclear-Squid
 [Moussx]:                  https://github.com/gagbo
 [Meriem]:                  https://mastodon.xyz/@meriem
-[Adrienm7]:                https://hypertexte.beseven.fr
+[Adrienm7]:                https://ergopti.fr
 [aurelberra]:              https://github.com/aurelberra
 [Xiloynaha]:               https://github.com/cypriani
 [Ju__]:                    https://github.com/PetitWombat


### PR DESCRIPTION
La disposition a été renommée d’HyperTexte➜Ergopti, le lien du site a donc changé