### PR TITLE
website: astuces installation

### DIFF
--- a/www/content/installation/index.md
+++ b/www/content/installation/index.md
@@ -84,11 +84,23 @@ Des pilotes incluant l’[angle-mod][] seront proposés. Il est d’ores et déj
 possible d’appliquer cet angle-mod et bien d’autres fonctionnalités via
 [kanata][] et la configuration [Arsenik][].
 
+
 Résolution de problèmes
 --------------------------------------------------------------------------------
 
 Vous avez des questions ou des problèmes avec les pilotes ? Consultez notre
 [FAQ] !
+
+
+Astuces
+--------------------------------------------------------------------------------
+
+### Disposition clavier par défaut sur Windows
+
+- Rechercher dans le menu Démarrer « Paramètres avancés de clavier »
+- Dans « Remplacer la méthode d’entrée par défaut » : choisir sa dispo préférée
+  dans le menu déroulant
+
 
 Licence
 --------------------------------------------------------------------------------

--- a/www/content/installation/index.md
+++ b/www/content/installation/index.md
@@ -97,8 +97,8 @@ Astuces
 
 ### Disposition clavier par défaut sur Windows
 
-- Rechercher dans le menu Démarrer « Paramètres avancés de clavier »
-- Dans « Remplacer la méthode d’entrée par défaut » : choisir sa dispo préférée
+1. Rechercher dans le menu Démarrer « Paramètres avancés de clavier »
+2. Dans « Remplacer la méthode d’entrée par défaut » : choisir sa dispo préférée
   dans le menu déroulant
 
 


### PR DESCRIPTION
Astuce pour mettre Ergo‑L en disposition clavier par défaut sur Windows.