### PR TITLE
website: fix deployment by updating GitHub

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./www/public
 
@@ -75,5 +75,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
L’erreur: https://github.com/Nuclear-Squid/ergol/actions/runs/13383923801/job/37377150480#step:1:29

Il faut mettre à jour [`actions/upload-pages-artifact`](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0), ce qui nécessite aussi de mettre à jour [`actions/deploy-pages`](https://github.com/actions/deploy-pages/releases/tag/v4.0.0). Il semblerait qu’il suffise de mettre à jour les numéros de version sans autres changements.