### PR TITLE
Supprime référence à ~/.profile dans la FAQ Linux

### DIFF
--- a/www/content/ressources/faq.md
+++ b/www/content/ressources/faq.md
@@ -62,9 +62,8 @@ deux frappes suivantes au lieu de la seule touche suivante dans certains
 programmes (ex: Firefox). C’est un
 [bug connu](https://gitlab.gnome.org/GNOME/gtk/-/issues/7201) de Gnome.
 
-Pour y remédier, il faut modifier votre fichier `~/.profile` (ou
-`/etc/environment` si vous voulez que le changement s’applique à toutes les
-sessions) et y ajouter les lignes suivantes :
+Pour y remédier, il faut modifier le fichier `/etc/environment` et y ajouter
+les lignes suivantes :
 
 ```bash
 INPUT_METHOD=ibus


### PR DESCRIPTION
Appliquer les changements dans ~/.profile ne fonctionne pas sur Ubuntu 24.04. En revanche, la solution mentionnée dans #177¹ qui consiste à modifier /etc/environment fonctionne.

¹: https://github.com/Nuclear-Squid/ergol/issues/177