### PR TITLE
Update duck-typist.js

### DIFF
--- a/code/duck-typist.js
+++ b/code/duck-typist.js
@@ -123,8 +123,8 @@ window.addEventListener('DOMContentLoaded', () => {
     const lessonLetters = rawLetters.concat(deadkeyLetters).join('');
     const newLettersCount = gLessonLevel == STARTING_LEVEL ? STARTING_LEVEL : INCLUDE_NEW_LETTERS;
     const newLetters = rawLetters.slice(-newLettersCount).join('');
-    const lessonRe = new RegExp(`^[${lessonLetters}]*[${newLetters}][${lessonLetters}]*$`)
-    const lessonFilter = word => lessonRe.test(word)
+    const lessonRe = new RegExp(`^[${lessonLetters}]*[${newLetters}][${lessonLetters}]*$`.replace(/-/g, '\\-'));
+    const lessonFilter = word => lessonRe.test(word);
 
     gLessonWords = [];
     for (const dict of [


### PR DESCRIPTION
duck typist generate regex with `-` in it, causing crash or unwanted behavior.

I didn’t test the code, just tested the replace part in the js console.