### PR TITLE
fix(website): highlight 1dk

### DIFF
--- a/www/static/img/ergol.svg
+++ b/www/static/img/ergol.svg
@@ -20,6 +20,8 @@
       --bg-number:        hsl(295, 100%, 95%);
       --bg-letter:        hsl(222, 100%, 95%);
       --bg-home:          hsl(222, 100%, 90%);
+      /* 1dk */
+      --bg-odk:           #7e7;
     }
 
     @media (prefers-color-scheme: dark) { :root {
@@ -37,6 +39,8 @@
       --bg-number:        hsl(280, 10%, 34%);
       --bg-letter:        hsl(220, 15%, 35%);
       --bg-home:          hsl(225, 30%, 30%);
+      /* 1dk */
+      --bg-odk:           #484;
     }}
 
     rect, path {
@@ -91,6 +95,10 @@
     :root:hover .level6.secondary { display: block; }
     .altgr .level5.secondary,
     .altgr .level6.secondary { display: none !important; }
+
+    /* highlight the dead key */
+    .mixed #odk,
+    .odk #odk { fill: var(--bg-odk); }
 
     /* show AltGr */
     .altgr .level3,
@@ -552,8 +560,8 @@
         <rect width="52" height="52" rx="5" ry="5"/>
         <g class="key" text-anchor="middle">
           <g class="level1 non_diacritic deadKey">
-            <text x="12.8" y="43.4" class="dk_mark">﹍</text>
-            <text x="12.8" y="43.4" class="dk_char">★</text>
+            <rect width="26" height="26" rx="5" ry="5" y="26" id="odk"/>
+            <text x="12.8" y="47.4" class="dk_char">★</text>
           </g>
           <text x="12.8" y="20.6" class="level2">!</text>
           <text x="38.0" y="43.4" class="level3">'</text>


### PR DESCRIPTION
Ceci est une proposition pour résoudre #341 (au moins partiellement), qui explique que l’UI de la vue SVG en page d’accueil est à revoir, et que le rôle de la touche morte n’est pas clair.

## Touche morte

De fait, dans les explications détaillées, on a mis la touche morte sur un fond vert, en reprenant la couleur des symboles en couche 1dk, pour mieux indiquer sa fonction.

![vue 1dk d’Ergol](https://ergol.org/presentation/ergol_1dk.svg)

Sur la page d’accueil (et les vues SVG en général), on pourrait donc utiliser le même fond vert : 

<img width="1100" height="366" alt="Image" src="https://github.com/user-attachments/assets/2bcb455b-3cb2-4120-b197-9929e7675a49" />

<img width="1100" height="366" alt="Image" src="https://github.com/user-attachments/assets/b397a6d1-73b4-4001-9953-7b6165d0417b" />

## Couche AltGr

Je *suppose* que le corollaire serait de mettre la touche AltGr en bleu sur les vues affichant les symboles, pour faire comme dans la section de présentation détaillée : 

![vue AltGr d’Ergol](https://ergol.org/presentation/ergol_altgr.svg)

Malheureusement, le bleu étant déjà utilisé pour le thème du SVG de la page d’accueil, il faudrait modifier ce thème de couleur si on veut mettre en évidence la touche AltGr.

## Patch ?

Cette PR ne sert qu’à voir si le fond vert sur `1dk` améliore la compréhension du rôle de la touche morte. Si c’est le cas : 
- on pourrait généraliser ça aux vues SVG des autres layouts (Lafayette, Bépolar, Erglace…)
- on pourrait envisager une modification du thème de couleur pour AltGr.