### PR TITLE
docs(CoC): règle de non-injonction

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,20 +33,23 @@ Comportement
    chaque choix d’ergonomie ou de disposition résulte de nombreux compromis qui
    peuvent être propres à chacun·e. Il y a rarement une bonne réponse pour tout
    le monde.
-4. Veillez à éviter la critique non structurée et personnelle.
-5. Peu importe qui vous êtes, si vous avez le sentiment d’avoir été harcelé·e ou
+4. Respectez le travail des contributeur·ices. Ces personnes font de leur mieux,
+   sur leur temps libre, pour proposer des outils à la communauté. Aucune
+   injonction ni aucune invective concernant leur travail ne sera entendable.
+5. Veillez à éviter la critique non structurée et personnelle.
+6. Peu importe qui vous êtes, si vous avez le sentiment d’avoir été harcelé·e ou
    mis·e dans une situation inconfortable par un membre de la communauté,
    contactez immédiatement l’équipe de modération : nous tenons à ce que tout le
    monde se sente à l’aise, et nous sommes là pour vous aider.
-6. Les comportements malveillants comme le spam, le troll, l’injure, la
+7. Les comportements malveillants comme le spam, le troll, l’injure, la
    provocation, la condescendance, l’agressivité passive, la diffamation ou tout
    autre mécanisme d’accaparement de l’attention ne sont pas les bienvenus.
-7. Pas d’autopromotion sauvage — ni en discussion publique, ni par message
+8. Pas d’autopromotion sauvage — ni en discussion publique, ni par message
    privé.
-8. Le serveur [Discord] dispose d’un canal dédié à la vente de matériel.
+9. Le serveur [Discord] dispose d’un canal dédié à la vente de matériel.
    L’utilisation de messages privés pour recommander ou vendre du matériel n’est
    pas tolérée et doit être signalée immédiatement à l’équipe de modération.
-9. [La liberté d’expression n’autorise personne à être toxique.](https://xkcd.com/1357/)
+10. [La liberté d’expression n’autorise personne à être toxique.](https://xkcd.com/1357/)
 
 
 Modération
@@ -99,7 +102,7 @@ et [OneDeadKey].
 Trolling][nodejs] et [Contributor Covenant v1.3.0][cco].)*
 
 
-[Discord]:    https://discord.gg/5xR5K3nAFX 
+[Discord]:    https://discord.gg/5xR5K3nAFX
 [Ergo‑L]:     https://github.com/Nuclear-Squid/ergol
 [OneDeadKey]: https://github.com/OneDeadKey/
 [Rust]:       https://www.rust-lang.org/fr/policies/code-of-conduct


### PR DESCRIPTION
Il semble que de nos jours, quand on arrive sur un projet libre, ça puisse être considéré acceptable d’invectiver les contributeur’ices et d’exiger de leur part du travail dans des délais arbitraires.

Or, non. Pas du tout. Ça ne l’a jamais été, et j’espère que ça ne le sera jamais.

Je suppose que ça marque la fin d’une époque, et qu’il est plus que temps que je rende mon tablier. Je propose cet ajout au code de conduite pour clarifier la règle, la formulation peut probablement être améliorée.