### PR TITLE
feat(website): corrections sur les pilotes

### DIFF
--- a/www/content/installation/index.md
+++ b/www/content/installation/index.md
@@ -43,6 +43,9 @@ Une archive ZIP contenant les pilotes ne nécessitant pas de droits
 d’administration, qui peuvent fonctionner depuis une clé USB. (Pour tous les
 systèmes.)
 
+Note : les scripts AHK peuvent être lancés sur Windows à l’aide
+d’[AutoHotkey][] v1 ou v2. Les .exe n’ont pas besoin de AHK pour fonctionner.
+
 ### Windows : [ergol_kbd.exe][]
 
 Exécuter l’installeur et relancer la session. La disposition de clavier
@@ -231,6 +234,7 @@ Licence
 [Karabiner]:                   https://karabiner-elements.pqrs.org
 [émulation ZMK]:               https://github.com/Nuclear-Squid/zmk-keyboard-quacken/pull/54
 
+[AutoHotkey]:                  https://www.autohotkey.com/
 [Arsenik]:                     /claviers/arsenik/
 [kanata]:                      https://github.com/jtroo/kanata
 [Ækeynox]:                     https://github.com/OneDeadKey/zmk-config-aekeynox

--- a/www/content/installation/index.md
+++ b/www/content/installation/index.md
@@ -44,7 +44,7 @@ d’administration, qui peuvent fonctionner depuis une clé USB. (Pour tous les
 systèmes.)
 
 Note : les scripts AHK peuvent être lancés sur Windows à l’aide
-d’[AutoHotkey][] v1 ou v2. Les .exe n’ont pas besoin de AHK pour fonctionner.
+d’[AutoHotkey][] v1.1 ou v2.0. Les .exe n’ont pas besoin de AHK pour fonctionner.
 
 ### Windows : [ergol_kbd.exe][]
 

--- a/www/content/installation/index.md
+++ b/www/content/installation/index.md
@@ -219,14 +219,14 @@ Licence
 
 [fichier source]:              /keymaps/fr/ergol.toml
 [cavalier.pdf]:                cavalier.pdf
-[ergol_nomade.zip]:            https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol_nomade.zip
-[ergol_kbd.exe]:               https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol_kbd.exe
-[ergol.keylayout]:             https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol.keylayout
-[ergol.xkb_symbols]:           https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol.xkb_symbols
-[ergol_angle_mod_nomade.zip]:  https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol_angle_mod_nomade.zip
-[ergol_angle_mod_kbd.exe]:     https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol_angle_mod_kbd.exe
-[ergol_angle_mod.xkb_symbols]: https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol_angle_mod.xkb_symbols
-[ergol_angle_mod.keylayout]:   https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.1/ergol_angle_mod.keylayout
+[ergol_nomade.zip]:            https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol_nomade.zip
+[ergol_kbd.exe]:               https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol_kbd.exe
+[ergol.keylayout]:             https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol.keylayout
+[ergol.xkb_symbols]:           https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol.xkb_symbols
+[ergol_angle_mod_nomade.zip]:  https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol_angle_mod_nomade.zip
+[ergol_angle_mod_kbd.exe]:     https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol_angle_mod_kbd.exe
+[ergol_angle_mod.xkb_symbols]: https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol_angle_mod.xkb_symbols
+[ergol_angle_mod.keylayout]:   https://github.com/Nuclear-Squid/ergol/releases/download/ergol-v1.0.2/ergol_angle_mod.keylayout
 [XKalamine]:                   https://github.com/OneDeadKey/kalamine#xkalamine
 [Karabiner]:                   https://karabiner-elements.pqrs.org
 [émulation ZMK]:               https://github.com/Nuclear-Squid/zmk-keyboard-quacken/pull/54


### PR DESCRIPTION
La release 1.0.2 est en draft ici visible pour les maintainers : https://github.com/Nuclear-Squid/ergol/releases

Elle contient les modifications suivantes :
- une correction des pilotes Windows kbd qui causaient des ralentissements à l’écran de connexion, et dans certains cas, l’impossibilité de lancer l’installation. Ils sont générés gracieusement par Ash avec la dernière version de KbdEdit (26.02.0 releasée le 28/02/2026)
  - peut-être que ça corrigera https://github.com/Nuclear-Squid/ergol/issues/387 dans la foulée ? À tester
- une correction pour le pilote angle-mod de macOS où la touche en haut à gauche de la ligne des chiffres est inversée avec la touche ISO (cf. [l’issue Kalamine](https://github.com/OneDeadKey/kalamine/issues/229) pour plus d’informations)
- une correction pour les pilotes angle-mod de macOS et Linux pour remplacer la touche ISO par Retour arrière et Shift+ISO par Suppr
  - corrige https://github.com/Nuclear-Squid/ergol/issues/377 si je n’ai pas fait d’erreur dans les fichiers xkb_symbols et xkb_keymap (je ne sais pas comment tester ça sur NixOS par contre :grimacing: )

Si la PR est OK pour validation, je publierai la release avant qu’on la valide svp, pour ne pas casser les liens sur le site.