### PR TITLE
Add missing extended scissors stats

### DIFF
--- a/code/layout-analyzer.js
+++ b/code/layout-analyzer.js
@@ -431,6 +431,7 @@ window.addEventListener('DOMContentLoaded', () => {
     showPercent('#sfu-all',        sum(ngrams.sfb),     2, '#Achoppements');
     showPercent('#extensions-all', sum(ngrams.lsb),     2, '#Achoppements');
     showPercent('#scissors-all',   sum(ngrams.scissor), 2, '#Achoppements');
+    showPercent('#extended-scissors-all', sum(ngrams.extendedScissor), 2, '#Achoppements');
 
     showPercent('#inward-all',  sum(ngrams.inwardRoll),  1, '#Bigrammes');
     showPercent('#outward-all', sum(ngrams.outwardRoll), 1, '#Bigrammes');
@@ -440,6 +441,7 @@ window.addEventListener('DOMContentLoaded', () => {
     achoppements.updateTableData('#sfu-digrams',    'SFU',        ngrams.sfb, 2);
     achoppements.updateTableData('#extended-rolls', 'LSB',        ngrams.lsb, 2,);
     achoppements.updateTableData('#scissors',       'ciseaux',    ngrams.scissor, 2);
+    achoppements.updateTableData('#extended-scissors', 'ciseaux en extension', ngrams.extendedScissor, 2);
 
     const bigrammes = document.getElementById('Bigrammes');
     bigrammes.updateTableData('#sku-digrams', 'SKU', ngrams.skb, 2);

--- a/www/content/stats.html
+++ b/www/content/stats.html
@@ -60,12 +60,14 @@ footer = "quantifié par [x-keyboard](https://onedeadkey.github.io/x-keyboard)"
     <span id="unsupported-all"></span> /
     <span id="sfu-all"></span> /
     <span id="extensions-all"></span> /
-    <span id="scissors-all"></span>
+    <span id="scissors-all"></span> /
+    <span id="extended-scissors-all"></span>
   </small>
   <table id="unsupported"></table>
   <table id="sfu-digrams"></table>
   <table id="extended-rolls"></table>
   <table id="scissors"></table>
+  <table id="extended-scissors"></table>
 </collapsable-table>
 
 <collapsable-table id="Bigrammes">


### PR DESCRIPTION
Corrige l’oubli des stats des ciseaux *en extension*