### PR TITLE
chore(website): upgrade Hugo version to 0.165.0

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,48 +32,64 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.123.0
+      HUGO_VERSION: 0.165.0
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
       - name: Install Pandoc
         run: sudo apt install pandoc
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
+          lfs: false
+
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
-      - name: Install Node.js dependencies
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
-      - name: Build with Hugo
-        env:
-          # For maximum backward compatibility with Hugo modules
-          HUGO_ENVIRONMENT: production
-          HUGO_ENV: production
+        uses: actions/configure-pages@v6
+
+      - name: Cache restore
+        id: cache-restore
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ runner.temp }}/.cache/hugo
+          key: hugo-${{ github.run_id }}
+          restore-keys: hugo-
+
+      - name: Build
         run: |
-          cd www && hugo \
+          echo "Building the project..."
+          cd www && hugo build \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+            --baseURL "${{ steps.pages.outputs.base_url }}/" \
+            --cacheDir "${{ runner.temp }}/.cache/hugo"
+
+      - name: Cache save
+        uses: actions/cache/save@v6
         with:
+          path: ${{ runner.temp }}/.cache/hugo
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          include-hidden-files: false
           path: ./www/public
 
   # Deployment job
   deploy:
+    runs-on: ubuntu-latest
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
-
+        uses: actions/deploy-pages@v5

--- a/www/hugo.toml
+++ b/www/hugo.toml
@@ -1,12 +1,14 @@
 # baseURL = "https://ergol.org"
 relativeURLs = false  # our 404 page does not support relative URLs
-languageCode = "fr"
+locale = "fr"
 title = "Ergo‑L"
 
 [params]
 subtitle = "Ergonomie optimisée pour le français, l’anglais, le code."
 description = "Une disposition de clavier ergonomique de type Colemak, optimisée pour le français, l’anglais et le code."
 
+[security]
+allowContent = ['text/html', 'text/markdown']
 [security.exec]
 allow = ["pandoc"]
 

--- a/www/layouts/_default/baseof.html
+++ b/www/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}"
-  dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<html lang="{{ or site.Language.Locale site.Language.Lang }}"
+  dir="{{ or site.Language.Direction `ltr` }}">
 
 <head>
   <title>

--- a/www/layouts/_default/home.html
+++ b/www/layouts/_default/home.html
@@ -8,7 +8,7 @@
 
   {{ range first 10 (where site.RegularPages "Section" "articles") }}
     <article>
-    {{ $author := index .Site.Data.authors (.Params.author | default "default") }}
+    {{ $author := index hugo.Data.authors (.Params.author | default "default") }}
       <header>
         <h3>{{ .LinkTitle }}</h3>
         <p class="author">

--- a/www/layouts/_default/list.html
+++ b/www/layouts/_default/list.html
@@ -4,7 +4,7 @@
     {{ range sort .Pages "Date" "desc" }}
       <article>
         <header>
-          {{ $author := index .Site.Data.authors (.Params.author | default "default") }}
+          {{ $author := index hugo.Data.authors (.Params.author | default "default") }}
           {{ $abstract := or .Params.abstract .Params.redirect_to .RelPermalink }}
           <h3>{{ .LinkTitle }}</h3>
           <p class="author">

--- a/www/layouts/_default/single.html
+++ b/www/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 
   {{ $date := .Date }}
-  {{ $author := index .Site.Data.authors (.Params.author | default "default") }}
+  {{ $author := index hugo.Data.authors (.Params.author | default "default") }}
 
   {{ if $author }}
     <p style="text-align: right;">


### PR DESCRIPTION
Je me suis inspirée de l’exemple de CI dans https://gohugo.io/host-and-deploy/host-on-github-pages/ (disclaimer : je ne m’y connais pas trop en CI Github).
Et j’ai testé le déploiement de [mon fork](https://trilowy.github.io/ergol/), ça a l’air OK.