### PR TITLE
fix(website): analyzer broken relative URL

### DIFF
--- a/www/layouts/shortcodes/x-keyboard.html
+++ b/www/layouts/shortcodes/x-keyboard.html
@@ -45,7 +45,7 @@
       {{ end }}
       {{ with .Get "data" }}
         <button disabled>⇪ Tester</button>
-        <a href="{{ (printf "stats/#/%s//en+fr" .) | relURL }}"><span>𝚺</span> Stats</a>
+        <a href="{{ "stats/" | relURL }}#/{{ . }}//en+fr"><span>𝚺</span> Stats</a>
         <a href="{{ (printf "dactylo/#%s" .) | relURL }}"><span>⌨</span> Apprendre</a><!-- 🎓 -->
       {{ end }}
     </nav>


### PR DESCRIPTION
Hugo changes // into / in URL made with relURL

This commit put ISO keyboard as a default in all URL, as nothing would also show ISO by default anyway